### PR TITLE
test: add missing tests for updateQuality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3009,6 +3009,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"

--- a/src/inventory/gilded_rose.spec.js
+++ b/src/inventory/gilded_rose.spec.js
@@ -1,11 +1,83 @@
 import { Item, updateQuality } from './gilded_rose';
 
 describe('`updateQuality`', () => {
+  //'Haunted Shoe' is a generic item and represents default behavior.
   it('deprecates the sell in by one for a Haunted Shoe', () => {
     const standardItem = new Item('Haunted Shoe', 10, 10);
     updateQuality([standardItem]);
     expect(standardItem.sell_in).toBe(9);
   });
 
-  it.todo('This is a good place for a good test!');
+  it('deprecates the quality by one for a Haunted Shoe while sell in is >=0', () => {
+    const standardItem = new Item('Haunted Shoe', 10, 10);
+    updateQuality([standardItem]);
+    expect(standardItem.quality).toBe(9);
+  });
+
+  it('deprecates the quality by 2 for a Haunted Shoe while sell in is <0', () => {
+    const standardItem = new Item('Haunted Shoe', 0, 10);
+    updateQuality([standardItem]);
+    expect(standardItem.quality).toBe(8);
+  });
+
+  it('does not lower quality of a Haunted Shoe below 0', () => {
+    const standardItem = new Item('Haunted Shoe', 10, 0);
+    updateQuality([standardItem]);
+    expect(standardItem.quality).toBe(0);
+  });
+
+  //Legendary items do not have sell by dates or decrease in quality.
+  //I am unsure if they are also supposed to have quality >50, as shown here.
+  it('does not lower the quality of a Hand of Ragnaros', () => {
+    const legendaryItem = new Item('Sulfuras, Hand of Ragnaros', 0, 80);
+    updateQuality([legendaryItem]);
+    expect(legendaryItem.quality).toBe(80);
+  })
+
+  //Aged Brie is meant to increase in quality as sell by decreases. It 
+  //should cap at 50 quality.
+  it('increments the quality of aged brie by 1 as sell-in decreases', () => {
+    const cheeseItem = new Item('Aged Brie', 10, 10);
+    updateQuality([cheeseItem]);
+    expect(cheeseItem.quality).toBe(11);
+  })
+
+  it('increments the quality of aged brie by 2 when sell-in <0', () => {
+    const cheeseItem = new Item('Aged Brie', 0, 10);
+    updateQuality([cheeseItem]);
+    expect(cheeseItem.quality).toBe(12);
+  })
+
+  it('cannot increment the quality of aged brie once it is 50', () => {
+    const cheeseItem = new Item('Aged Brie', 50, 50);
+    updateQuality([cheeseItem]);
+    expect(cheeseItem.quality).toBe(50);
+  })
+
+  //Tickets go up by 2 quality once sell-in <=10, but their quality is locked 
+  //at 0 once sell-in <=0. They are otherwise identical to aged brie.
+  it('increments the quality of tickets by 1 while sell-in >10', () => {
+    const ticketItem = new Item('Backstage passes to a TAFKAL80ETC concert', 15, 10);
+    updateQuality([ticketItem]);
+    expect(ticketItem.quality).toBe(11);
+  })
+
+  it('increments the quality of tickets by 2 while sell-in <=10', () => {
+    const ticketItem = new Item('Backstage passes to a TAFKAL80ETC concert', 10, 10);
+    updateQuality([ticketItem]);
+    expect(ticketItem.quality).toBe(12);
+  })
+
+  it('sets the quality of tickets to 0 when sell-in is 0', () => {
+    const ticketItem = new Item('Backstage passes to a TAFKAL80ETC concert', 0, 10);
+    updateQuality([ticketItem]);
+    expect(ticketItem.quality).toBe(0);
+  })
+
+  it('does not change quality after sell-in drops below 0', () => {
+    const ticketItem = new Item('Backstage passes to a TAFKAL80ETC concert', 0, 10);
+    updateQuality([ticketItem]);
+    updateQuality([ticketItem]);
+    expect(ticketItem.quality).toBe(0);
+  })
 });


### PR DESCRIPTION
## Description
Adds additional tests for `guilded_rose`'s `updateQuality()` function. Test coverage for that function was very poor, and these additional tests are intended to boost that coverage to at least 90%.

## Spec

See Issue: [FSA22V2-75](https://sparkbox.atlassian.net/browse/FSA22V2-75)

## Validation
<!-- delete anything irrelevant to this PR -->

- [ ] All tests, both new and old, still pass.
- [ ] Test coverage is at least 90%.

### To Validate

1. Make sure all PR Checks have passed.
2. Pull down `test--updateQuality` branch.
3. After installing dependencies (npm -i), run `npm test` to see if all tests pass.
3. Run `npm run test:coverage` to check if test coverage is >90%. 
